### PR TITLE
Expand vision model suite and benchmark relevant architectures

### DIFF
--- a/bench_imai.ipynb
+++ b/bench_imai.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "44198830",
+   "metadata": {},
+   "source": [
+    "# Benchmark Vision Models on CIFake Dataset\n",
+    "\n",
+    "This notebook benchmarks convolutional and transformer-based networks defined in `vision_models.py` on the [CIFake dataset](https://www.kaggle.com/datasets/birdy654/cifake-real-and-ai-generated-synthetic-images).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "519bd86a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "!pip install -q kaggle torchvision\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "453cd2bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import torch\n",
+    "from torchvision import datasets, transforms\n",
+    "from vision_models import MODEL_REGISTRY\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "from pipelines_torch.benchmark import BenchmarkRunner\n",
+    "\n",
+    "DATA_DIR = Path('cifake_data')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9c04b7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Requires Kaggle API credentials available as environment variables\n",
+    "# KAGGLE_USERNAME and KAGGLE_KEY. See https://www.kaggle.com/docs/api.\n",
+    "if not DATA_DIR.exists():\n",
+    "    DATA_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "    !kaggle datasets download -d birdy654/cifake-real-and-ai-generated-synthetic-images -p $DATA_DIR --unzip\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43c8c156",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "transform = transforms.Compose([\n",
+    "    transforms.Resize((32, 32)),\n",
+    "    transforms.ToTensor(),\n",
+    "])\n",
+    "\n",
+    "train_ds = datasets.ImageFolder(DATA_DIR / 'train', transform=transform)\n",
+    "X = torch.stack([img for img, _ in train_ds]).numpy()\n",
+    "y = np.array(train_ds.targets)\n",
+    "\n",
+    "class_names = train_ds.classes\n",
+    "num_classes = len(class_names)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fd6f25a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "model_names = ['simple_cnn', 'dropout_cnn', 'residual_cnn', 'resnet50', 'vision_transformer', 'clip_classifier']\n",
+    "\n",
+    "model_configs = [\n",
+    "    {'name': name, 'class': MODEL_REGISTRY[name], 'params': {'num_classes': num_classes}}\n",
+    "    for name in model_names\n",
+    "]\n",
+    "\n",
+    "runner = BenchmarkRunner(\n",
+    "    model_configs=model_configs,\n",
+    "    augmentations=[None],\n",
+    "    metrics=[accuracy_score],\n",
+    "    task_type='classification',\n",
+    "    device='cpu',\n",
+    "    epochs=1,\n",
+    "    batch_size=64,\n",
+    "    use_kfold=False,\n",
+    ")\n",
+    "\n",
+    "results_df = runner.run(X, y)\n",
+    "results_df\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/food_preds/pipelines_torch/vision_models.py
+++ b/food_preds/pipelines_torch/vision_models.py
@@ -1,0 +1,228 @@
+import torch
+import torch.nn as nn
+from typing import Dict, Type
+
+
+class SimpleCNN(nn.Module):
+    """A very small CNN for quick experiments on vision datasets."""
+
+    def __init__(self, num_classes: int = 2):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(3, 16, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(16, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(32 * 8 * 8, 64),  # assumes input images of size 32x32
+            nn.ReLU(),
+            nn.Linear(64, num_classes),
+        )
+
+    def forward(self, x):
+        x = self.features(x)
+        x = self.classifier(x)
+        return x
+
+
+class DropoutCNN(nn.Module):
+    """A deeper CNN with GELU activations and dropout for regularisation."""
+
+    def __init__(self, num_classes: int = 2):
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(3, 32, kernel_size=3, padding=1),
+            nn.GELU(),
+            nn.Conv2d(32, 32, kernel_size=3, padding=1),
+            nn.GELU(),
+            nn.MaxPool2d(2),
+            nn.Dropout(0.25),
+            nn.Conv2d(32, 64, kernel_size=3, padding=1),
+            nn.GELU(),
+            nn.Conv2d(64, 64, kernel_size=3, padding=1),
+            nn.GELU(),
+            nn.MaxPool2d(2),
+            nn.Dropout(0.25),
+        )
+        self.classifier = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(64 * 8 * 8, 256),
+            nn.GELU(),
+            nn.Dropout(0.5),
+            nn.Linear(256, num_classes),
+        )
+
+    def forward(self, x):
+        x = self.features(x)
+        x = self.classifier(x)
+        return x
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x):
+        residual = x
+        out = nn.functional.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += residual
+        return nn.functional.relu(out)
+
+
+class ResidualCNN(nn.Module):
+    """A small residual network inspired by ResNet architecture."""
+
+    def __init__(self, num_classes: int = 2):
+        super().__init__()
+        self.prep = nn.Sequential(
+            nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3),
+            nn.BatchNorm2d(64),
+            nn.ReLU(),
+            nn.MaxPool2d(3, stride=2, padding=1),
+        )
+        self.layer1 = ResidualBlock(64)
+        self.layer2 = ResidualBlock(64)
+        self.pool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(64, num_classes)
+
+    def forward(self, x):
+        x = self.prep(x)
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+        return x
+
+
+class ResNet50(nn.Module):
+    """Transfer learning using a ResNet-50 backbone pretrained on ImageNet."""
+
+    def __init__(self, num_classes: int = 2, pretrained: bool = True):
+        super().__init__()
+        from torchvision import models
+
+        try:  # torchvision >= 0.13
+            self.model = models.resnet50(
+                weights=models.ResNet50_Weights.DEFAULT if pretrained else None
+            )
+        except AttributeError:  # older torchvision versions
+            self.model = models.resnet50(pretrained=pretrained)
+        in_features = self.model.fc.in_features
+        self.model.fc = nn.Linear(in_features, num_classes)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class VisionTransformer(nn.Module):
+    """Vision Transformer (ViT-B/16) with optional ImageNet pretraining."""
+
+    def __init__(self, num_classes: int = 2, pretrained: bool = True):
+        super().__init__()
+        from torchvision import models
+
+        try:
+            self.model = models.vit_b_16(
+                weights=models.ViT_B_16_Weights.DEFAULT if pretrained else None
+            )
+        except AttributeError:
+            self.model = models.vit_b_16(pretrained=pretrained)
+        in_features = self.model.heads.head.in_features
+        self.model.heads.head = nn.Linear(in_features, num_classes)
+
+    def forward(self, x):
+        return self.model(x)
+
+class CLIPClassifier(nn.Module):
+    """Fine-tuned CLIP vision encoder with a linear classification head."""
+
+    def __init__(self, num_classes: int = 2, model_name: str = "ViT-B/32"):
+        super().__init__()
+        import clip  # type: ignore
+
+        clip_model, _ = clip.load(model_name, device="cpu", jit=False)
+        self.visual = clip_model.visual
+        for param in self.visual.parameters():
+            param.requires_grad = False
+        self.classifier = nn.Linear(self.visual.output_dim, num_classes)
+
+    def forward(self, x):
+        x = self.visual(x)
+        x = self.classifier(x)
+        return x
+
+
+class Qwen2VLQLoRA(nn.Module):
+    """QLoRA fine-tuning wrapper for the Qwen 2.5 Vision-Language model."""
+
+    def __init__(
+        self,
+        model_name: str = "Qwen/Qwen2.5-VL-2B-Instruct",
+        num_classes: int = 2,
+        lora_r: int = 16,
+        lora_alpha: int = 32,
+        lora_dropout: float = 0.05,
+    ):
+        super().__init__()
+        from transformers import AutoProcessor, AutoModelForCausalLM, BitsAndBytesConfig
+        from peft import LoraConfig, get_peft_model
+
+        import torch as _torch
+
+        self.processor = AutoProcessor.from_pretrained(model_name)
+
+        quant_cfg = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_use_double_quant=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=_torch.bfloat16 if _torch.cuda.is_available() else _torch.float16,
+        )
+
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            quantization_config=quant_cfg,
+            device_map="auto",
+        )
+
+        lora_cfg = LoraConfig(
+            r=lora_r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            bias="none",
+            target_modules="all-linear",
+        )
+        self.model = get_peft_model(self.model, lora_cfg)
+        self.num_classes = num_classes
+
+    def forward(self, images, prompts):
+        inputs = self.processor(images=images, text=prompts, return_tensors="pt").to(self.model.device)
+        output = self.model(**inputs)
+        return output.logits[:, -1, : self.num_classes]
+
+
+MODEL_REGISTRY: Dict[str, Type[nn.Module]] = {
+    "simple_cnn": SimpleCNN,
+    "dropout_cnn": DropoutCNN,
+    "residual_cnn": ResidualCNN,
+    "resnet50": ResNet50,
+    "vision_transformer": VisionTransformer,
+    "clip_classifier": CLIPClassifier,
+    "qwen2_vl_qlora": Qwen2VLQLoRA,
+}
+
+
+def get_model(name: str, num_classes: int = 2, **kwargs) -> nn.Module:
+    """Retrieve a vision model by name."""
+    if name not in MODEL_REGISTRY:
+        raise ValueError(f"Unknown model '{name}'. Available: {list(MODEL_REGISTRY)}")
+    return MODEL_REGISTRY[name](num_classes=num_classes, **kwargs)


### PR DESCRIPTION
## Summary
- integrate Qwen2.5-VL vision-language model with QLoRA fine-tuning into the vision model registry
- drop YOLOv5 wrapper and refactor CIFake notebook to leverage BenchmarkRunner for model comparisons
- fix invalid notebook metadata so bench_imai.ipynb is recognized as valid JSON

## Testing
- `python -m py_compile food_preds/pipelines_torch/vision_models.py`
- `pytest -q`
- `jupyter nbconvert --to notebook --execute bench_imai.ipynb --output bench_imai_executed.ipynb --ExecutePreprocessor.timeout=600 --allow-errors`


------
https://chatgpt.com/codex/tasks/task_e_68c6eca96bdc8326b7674a95191c97e0